### PR TITLE
Prepare for some of the Blaze changes in 0.9.1

### DIFF
--- a/dynamic_template.js
+++ b/dynamic_template.js
@@ -252,10 +252,10 @@ DynamicTemplate.prototype.insert = function (options) {
   if (!this.view)
     this.create(options);
 
-  if (!this.range)
-    this.range = Blaze.render(this.view, options.parentView);
+  Blaze.withCurrentView(this.view, function () {
+    Blaze.render(this.view, $el[0], options.nextNode);
+  });
 
-  this.range.attach($el[0], options.nextNode);
   return this;
 };
 


### PR DESCRIPTION
This makes all test pass against the current revision (01775074928cfe06f9276ea7cfae5583adad2ab9) of the 'blaze-templates' branch (which will be part of 0.9.1).

There will be another change for 0.9.1, not yet implemented -- ReactiveVar will be its own package rather than in the UI namespace, but I think we'll backcompat it. So maybe this is all that's needed for 0.9.1 support on iron-dynamic-template.

Oh. I haven't fixed `UI.registerHelper('DynamicTemplate', Template.__create__(...))` yet but I guess tests don't exercise that? Or maybe we have backcompat? I'll check.

Next up: look at iron-layout
