### PR TITLE
Adding package name for local Windows development

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,8 @@
 Package.describe({
   summary: 'Dynamically create and update templates and their data contexts.',
   version: "1.0.0-pre3",
-  git: "https://github.com/eventedmind/iron-dynamic-template"
+  git: "https://github.com/eventedmind/iron-dynamic-template",
+  name: 'iron:dynamic-template'
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
More background on this here: https://forums.meteor.com/t/local-packages-on-windows/6656

Essentially, I'd like to use iron router (great work!) but I need to store it locally, and also work on Windows.  The semi-colon is illegal in Windows file names, so I've added the name parameter to each of the iron packages that was missing it to allow local packages on Windows.

Thanks!
