### PR TITLE
refactor: use jQuery as a weak dependency (similar as Blaze)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ Iron.DynamicTemplate
 ===============================================================
 Dynamic templates and data contexts for Meteor.
 
+## Installation
+This package has a weak dependency on jQuery (similar as Blaze),
+so you can add jQuery to your Meteor app from a [CDN](https://code.jquery.com/) or a [Meteor package](https://atmospherejs.com/meteor/jquery):
+```
+meteor add jquery
+```
+
 ## Templates and Helpers
 
 ```html

--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.on_use(function (api) {
   api.use('blaze');
   api.use('underscore');
   api.use('ui');
-  api.use('jquery');
+  api.use("jquery", { weak: true });
   api.use('tracker');
   api.use('reactive-var');
   api.use('templating');

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: 'https://github.com/iron-meteor/iron-dynamic-template'
 });
 
-Package.on_use(function (api) {
+Package.onUse(function (api) {
   api.versionsFrom('METEOR@0.9.2');
 
   api.use('blaze');
@@ -20,13 +20,13 @@ Package.on_use(function (api) {
   api.use('iron:core@1.0.11');
   api.imply('iron:core');
 
-  api.add_files('version_conflict_error.js');
-  api.add_files('dynamic_template.html');
-  api.add_files('dynamic_template.js');
-  api.add_files('blaze_overrides.js');
+  api.addFiles('version_conflict_error.js');
+  api.addFiles('dynamic_template.html');
+  api.addFiles('dynamic_template.js');
+  api.addFiles('blaze_overrides.js');
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   api.versionsFrom('METEOR@0.9.2');
 
   api.use('iron:dynamic-template');
@@ -36,6 +36,6 @@ Package.on_test(function (api) {
   api.use('blaze');
   api.use('deps');
 
-  api.add_files('dynamic_template_test.html', 'client');
-  api.add_files('dynamic_template_test.js', 'client');
+  api.addFiles('dynamic_template_test.html', 'client');
+  api.addFiles('dynamic_template_test.js', 'client');
 });


### PR DESCRIPTION
Now we are able to add jQuery from CDN directly to <head>.
jQuery does not need to be part of the initial JS bundle (and users might have it cached already)